### PR TITLE
Implement configuration module and logging improvements

### DIFF
--- a/account.py
+++ b/account.py
@@ -1,5 +1,6 @@
 from tastytrade import Account as ac
 import logging
+from config import ACCOUNT_ID
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +13,12 @@ class Account:
         return cls._instance
 
     def __init__(self, session):
-        if not hasattr(self, 'initialized'):  # Check if it's the first time __init__ is called
+        if not hasattr(self, 'initialized'):
+            if not ACCOUNT_ID:
+                raise ValueError("TT_ACCOUNT_ID environment variable not set")
             try:
-                self._account = ac.get(session, '5WV52737')
-                self.initialized = True  # Mark as initialized
+                self._account = ac.get(session, ACCOUNT_ID)
+                self.initialized = True
             except Exception as e:
                 logger.error(f"Failed to initialize Account: {str(e)}")
                 raise

--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ACCOUNT_ID = os.getenv('TT_ACCOUNT_ID')
+TT_API_CLIENT_SECRET = os.getenv('TT_API_CLIENT_SECRET')
+TT_REFRESH_TOKEN = os.getenv('TT_REFRESH_TOKEN')
+SPREADSHEET_URL = os.getenv('SPREADSHEET_URL', 'https://docs.google.com/spreadsheets/d/1A528mC08exsLG9tXSoVhF-vZsuRGwspOxRpEhPNwbpE/edit?usp=sharing')
+SPREADSHEET_ID = os.getenv('SPREADSHEET_ID', '1A528mC08exsLG9tXSoVhF-vZsuRGwspOxRpEhPNwbpE')
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'ERROR').upper()
+GREEK_POLL_INTERVAL = int(os.getenv('GREEK_POLL_INTERVAL', '5'))

--- a/market_data.py
+++ b/market_data.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from dataclasses import dataclass, field
 from threading import Thread
 from typing import Any, ClassVar, Dict, List
@@ -71,7 +70,6 @@ class MarketData():
 
     def stop_streamer(self) -> None:
         self._stop_streaming = True
-        time.sleep(5)
         self._thread_runs = False
 
     def _subscribe_symbol(self, event_type: EventType, symbols: List[str]) -> None:
@@ -79,7 +77,6 @@ class MarketData():
         if new_symbols:
             self._new_symbols[event_type] = new_symbols
             self._subscribed_symbols[event_type] = list(set(self._subscribed_symbols[event_type]) | set(symbols))
-            time.sleep(5)
 
     def _get_events(self, event_type: EventType, symbols: List[str]) -> List[Greeks] | List[Trade] | List[Quote] | None:
         market_data = list(self._cached_events[event_type].values())


### PR DESCRIPTION
## Summary
- centralize configurable values in new `config` module
- move account id and API credentials to environment variables
- improve session refresh logic
- streamline market data streaming and logging
- refactor sheets formatting API calls
- initialize streamer in `main` instead of import time

## Testing
- `python -m py_compile account.py session.py market_data.py sheets.py update_dashboard.py utils.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_688bec02829c8333a1cf7e5ea2c0f4bf